### PR TITLE
add ability to specify provider profile for groups

### DIFF
--- a/deployment-configs/10k-shared-compute.yaml
+++ b/deployment-configs/10k-shared-compute.yaml
@@ -1,3 +1,4 @@
+default_provider_profile: 24cpu-128G-1T-intel-hdd
 layout:
   sites:
     - east
@@ -7,39 +8,8 @@ layout:
   rows_per_site: 5
   racks_per_row: 25
   nodes_per_rack: 20
-profiles:
-  standard.compute.localdisk:
-    sites:
-      - east
-      - west
-      - north
-      - south
-    capabilities:
-      - hw.cpu.x86.avx2
-      - hw.cpu.x86.vmx
-      - storage.disk.hdd
-    inventory:
-      runm.cpu.shared:
-        total: 24
-        reserved: 0
-        allocation_ratio: 16.0
-      runm.memory:
-        # 128GiB
-        total: 137438953472
-        # 256MiB
-        reserved: 268435456
-        allocation_ratio: 1.5
-        # 64MiB
-        min_unit: 67108864
-        # 96GiB
-        max_unit: 103079215104
-        # 64MiB
-        step_size: 67108864
-      runm.block_storage:
-        # 1000GB
-        total: 1000000000000
-        allocation_ratio: 1.0
-        # 10GB
-        min_unit: 10000000000
-        # 10GB
-        step_size: 10000000000
+group_provider_profiles:
+  east: 24cpu-128G-1T-intel-hdd
+  west: 24cpu-128G-1T-intel-hdd
+  north: 24cpu-128G-1T-intel-hdd
+  south: 24cpu-128G-1T-intel-hdd

--- a/deployment-configs/1k-shared-compute.yaml
+++ b/deployment-configs/1k-shared-compute.yaml
@@ -1,3 +1,4 @@
+default_provider_profile: 24cpu-128G-1T-intel-hdd
 layout:
   sites:
     - east
@@ -5,37 +6,6 @@ layout:
   rows_per_site: 2
   racks_per_row: 25
   nodes_per_rack: 20
-profiles:
-  standard.compute.localdisk:
-    sites:
-      - east
-      - west
-    capabilities:
-      - hw.cpu.x86.avx2
-      - hw.cpu.x86.vmx
-      - storage.disk.hdd
-    inventory:
-      runm.cpu.shared:
-        total: 24
-        reserved: 0
-        allocation_ratio: 16.0
-      runm.memory:
-        # 128GiB
-        total: 137438953472
-        # 256MiB
-        reserved: 268435456
-        allocation_ratio: 1.5
-        # 64MiB
-        min_unit: 67108864
-        # 96GiB
-        max_unit: 103079215104
-        # 64MiB
-        step_size: 67108864
-      runm.block_storage:
-        # 1000GB
-        total: 1000000000000
-        allocation_ratio: 1.0
-        # 10GB
-        min_unit: 10000000000
-        # 10GB
-        step_size: 10000000000
+group_provider_profiles:
+  east: 24cpu-128G-1T-intel-hdd
+  west: 24cpu-128G-1T-intel-hdd

--- a/load.py
+++ b/load.py
@@ -429,14 +429,14 @@ def create_providers(ctx):
     ctx.status_ok()
 
     ctx.status("caching resource class and capability internal IDs")
-    for prof in ctx.deployment_config.profiles.values():
-        for rc_code in prof['inventory'].keys():
+    for prof in ctx.deployment_config.provider_profiles.values():
+        for rc_code in prof.inventory.keys():
             if rc_code not in rc_ids:
                 sel = sa.select([rc_tbl.c.id]).where(rc_tbl.c.code == rc_code)
                 res = sess.execute(sel).fetchone()
                 rc_id = res[0]
                 rc_ids[rc_code] = rc_id
-        for cap_code in prof['capabilities']:
+        for cap_code in prof.capabilities:
             if cap_code not in cap_ids:
                 sel = sa.select([cap_tbl.c.id]).where(
                     cap_tbl.c.code == cap_code)

--- a/provider-profiles/24cpu-128G-1T-intel-hdd.yaml
+++ b/provider-profiles/24cpu-128G-1T-intel-hdd.yaml
@@ -1,0 +1,29 @@
+capabilities:
+  - hw.cpu.x86.avx2
+  - hw.cpu.x86.vmx
+  - storage.disk.hdd
+inventory:
+  runm.cpu.shared:
+    total: 24
+    reserved: 0
+    allocation_ratio: 16.0
+  runm.memory:
+    # 128GiB
+    total: 137438953472
+    # 256MiB
+    reserved: 268435456
+    allocation_ratio: 1.5
+    # 64MiB
+    min_unit: 67108864
+    # 96GiB
+    max_unit: 103079215104
+    # 64MiB
+    step_size: 67108864
+  runm.block_storage:
+    # 1000GB
+    total: 1000000000000
+    allocation_ratio: 1.0
+    # 10GB
+    min_unit: 10000000000
+    # 10GB
+    step_size: 10000000000

--- a/provider_profile.py
+++ b/provider_profile.py
@@ -1,0 +1,56 @@
+import copy
+import os
+
+import yaml
+
+import resource_models
+
+
+class ProviderProfile(object):
+    """A provider profile describes the inventory and capabilities for a
+    provider.
+    """
+    def __init__(self, fp):
+        """Loads the deployment configuration from a supplied filepath to a
+        YAML file.
+        """
+        if not fp.endswith('.yaml'):
+            fp = fp + '.yaml'
+        if not os.path.exists(fp):
+            raise RuntimeError("Unable to load provider profile %s. "
+                               "File does not exist." % fp)
+
+        with open(fp, 'rb') as f:
+            try:
+                config_dict = yaml.load(f)
+            except yaml.YAMLError as err:
+                raise RuntimeError("Unable to load provider profile "
+                                   "%s. Problem parsing file: %s." % (fp, err))
+        name = os.path.basename(fp).rstrip('.yaml')
+        self.name = name
+        # Simple list of capability names that the provider has
+        self.capabilities = config_dict.get('capabilities', [])
+        # dict, keyed by resource class name, of inventory information this
+        # provider profile contains. The inventory information includes total,
+        # reserved, min_unit, max_unit, step_size and allocation_ratio data
+        # points for that resource class.
+        self.inventory = self._load_inventory(config_dict['inventory'])
+
+    def __repr__(self):
+        return "ProviderProfile(name=%s)" % self.name
+
+    def _load_inventory(self, block):
+        all_inv = {}
+        for rc_name, inv in block.items():
+            if 'min_unit' not in inv:
+                inv['min_unit'] = 1
+            if 'max_unit' not in inv:
+                inv['max_unit'] = inv['total']
+            if 'step_size' not in inv:
+                inv['step_size'] = 1
+            if 'allocation_ratio' not in inv:
+                inv['allocation_ratio'] = 1.0
+            if 'reserved' not in inv:
+                inv['reserved'] = 0
+            all_inv[rc_name] = inv
+        return all_inv

--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ import claim
 import load
 import claim_config
 import deployment_config
+import provider_profile
 import resource_models
 
 _LOG_FORMAT = "%(level)s %(message)s"
@@ -22,6 +23,9 @@ _CLAIM_CONFIGS_DIR = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'claim-configs',
 )
 _DEFAULT_CLAIM_CONFIG = '1cpu-64M-10G'
+_PROVIDER_PROFILES_DIR = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), 'provider-profiles',
+)
 
 
 class RunContext(object):
@@ -87,10 +91,17 @@ def setup_opts(parser):
 
 
 def main(ctx):
+    prov_profiles = {}
+    for fn in os.listdir(_PROVIDER_PROFILES_DIR):
+        fp = os.path.join(_PROVIDER_PROFILES_DIR, fn)
+        if os.path.isfile(fp) and fn.endswith('.yaml'):
+            prof_name = fn[0:len(fn) - 5]
+            prov_profiles[prof_name] = provider_profile.ProviderProfile(fp)
     if ctx.args.reset:
         ctx.status("loading deployment config")
         fp = os.path.join(_DEPLOYMENT_CONFIGS_DIR, args.deployment_config)
-        ctx.deployment_config = deployment_config.DeploymentConfig(fp)
+        ctx.deployment_config = deployment_config.DeploymentConfig(
+            fp, prov_profiles)
         ctx.status_ok()
         load.load(ctx)
     find_claims(ctx)


### PR DESCRIPTION
Carves off the ProviderProfile into its own separate thing and modifies
the deployment-config structure to allow specifying a default provider
profile to use for the deployment as well as overrides for any group of
providers. This way, deployment configurations can be created that
override, for instance, just one rack of compute in a particular site to
have, say, SSD instead of HDD for disk storage.

Issue #2