### PR TITLE
correct bug in _find_provider_with_all_caps()

### DIFF
--- a/claim-configs/1cpu-64M-10G-complex-caps.yaml
+++ b/claim-configs/1cpu-64M-10G-complex-caps.yaml
@@ -12,8 +12,10 @@ request_groups:
         min: 1000000000
         max: 1000000000
     capabilities:
-      - any:
-          - cpu.x86.avx
+      - require:
           - cpu.x86.vmx
+        any:
+          - cpu.x86.avx
+          - cpu.x86.avx2
       - forbid:
           - storage.disk.ssd

--- a/claim.py
+++ b/claim.py
@@ -472,7 +472,7 @@ def _find_providers_with_all_caps(ctx, caps, limit=50):
     ).group_by(
         p_caps_tbl.c.provider_id
     ).having(
-        func.count(p_caps_tbl.c.capability_id) == len(required_caps)
+        func.count(p_caps_tbl.c.capability_id) == len(caps)
     )
     if limit != UNLIMITED:
         sel = sel.limit(limit)


### PR DESCRIPTION
When mixing in "require" into one of the capability constraints in the
1cpu-64M-10G-complex-caps claim configuration, I ran into an issue with
the _find_provider_with_all_caps() function that was due to a
previously-renamed variable. This patch fixes that bug and makes the
changes to the aforementioned claim config.

Issue #2