### PR TITLE
add basic claim execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ loading deployment config ... ok
 resetting resource PoC database ... ok
 creating object types ... ok
 creating provider types ... ok
-creating resource classes ... ok
+creating resource types ... ok
 creating consumer types ... ok
 creating capabilities ... ok
 creating distance types ... ok
@@ -102,7 +102,7 @@ creating distances ... ok
 creating partitions ... ok
 creating provider groups ... ok
 caching provider group internal IDs ... ok
-caching resource class and capability internal IDs ... ok
+caching resource type and capability internal IDs ... ok
 caching partition, distance type and distance internal IDs ... ok
 creating providers ... ok
 loading claim config ... ok
@@ -111,7 +111,7 @@ Found 50 providers with capacity for 67108864 runm.memory
 Found 50 providers with capacity for 1 runm.cpu.shared
 Claim(allocation=
     Allocation(consumer=Consumer(name=instance0,uuid=e8495d7172714de0a0106e6a4c4927f7),claim_time=1540490434,release_time=9223372036854775807,items=[
-        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_class=runm.block_storage,used=1000000000),
-        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_class=runm.memory,used=67108864),
-        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_class=runm.cpu.shared,used=1)]))
+        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_type=runm.block_storage,used=1000000000),
+        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_type=runm.memory,used=67108864),
+        AllocationItem(provider=Provider(uuid=00af7f6b00224f81acea148e3318fe34),resource_type=runm.cpu.shared,used=1)]))
 ```

--- a/claim-configs/1cpu-64M-10G-complex-caps.yaml
+++ b/claim-configs/1cpu-64M-10G-complex-caps.yaml
@@ -12,8 +12,10 @@ request_groups:
         min: 1000000000
         max: 1000000000
     capabilities:
-      - any:
-          - cpu.x86.avx
+      - require:
           - cpu.x86.vmx
+        any:
+          - cpu.x86.avx
+          - cpu.x86.avx2
       - forbid:
           - storage.disk.ssd

--- a/claim.py
+++ b/claim.py
@@ -472,7 +472,7 @@ def _find_providers_with_all_caps(ctx, caps, limit=50):
     ).group_by(
         p_caps_tbl.c.provider_id
     ).having(
-        func.count(p_caps_tbl.c.capability_id) == len(required_caps)
+        func.count(p_caps_tbl.c.capability_id) == len(caps)
     )
     if limit != UNLIMITED:
         sel = sel.limit(limit)

--- a/deployment-configs/100-dedicated-compute.yaml
+++ b/deployment-configs/100-dedicated-compute.yaml
@@ -1,0 +1,7 @@
+default_provider_profile: 12cpu-64G-4T-ssd-dedicated
+layout:
+  sites:
+    - east
+  rows_per_site: 1
+  racks_per_row: 4
+  nodes_per_rack: 25

--- a/deployment-configs/100-mixed-compute.yaml
+++ b/deployment-configs/100-mixed-compute.yaml
@@ -1,0 +1,11 @@
+default_provider_profile: 24cpu-128G-1T-intel-hdd-shared
+layout:
+  sites:
+    - east
+  rows_per_site: 1
+  racks_per_row: 4
+  nodes_per_rack: 25
+group_provider_profiles:
+  # Within the site, there is one rack in one row that contains dedicated
+  # compute. All other machines are shared compute
+  east-row1-rack1: 12cpu-64G-4T-ssd-dedicated

--- a/deployment-configs/100-shared-compute.yaml
+++ b/deployment-configs/100-shared-compute.yaml
@@ -1,0 +1,7 @@
+default_provider_profile: 24cpu-128G-1T-intel-hdd-shared
+layout:
+  sites:
+    - east
+  rows_per_site: 1
+  racks_per_row: 4
+  nodes_per_rack: 25

--- a/deployment_config.py
+++ b/deployment_config.py
@@ -39,7 +39,8 @@ class DeploymentConfig(object):
         self.partitions = {}
         self._load_partitions()
         # A hashmap of provider group name to provider profile name
-        self.group_provider_profiles = config_dict['group_provider_profiles']
+        g_profiles = config_dict.get('group_provider_profiles', {})
+        self.group_provider_profiles = g_profiles
         # A hashmap of provider group name to provider group object
         self.provider_groups = {}
         self._load_provider_groups()

--- a/load.py
+++ b/load.py
@@ -6,13 +6,13 @@ import subprocess
 
 import sqlalchemy as sa
 
+import lookup
 import metadata
 import resource_models
 
 _RESOURCE_SCHEMA_FILE = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'resource_schema.sql',
 )
-_PROVIDER_TYPE_MAP = None
 
 
 def _insert_records(tbl, recs):
@@ -85,20 +85,6 @@ def create_provider_types(ctx):
         ctx.status_ok()
     except Exception as err:
         ctx.status_fail(err)
-
-
-def get_provider_type_map():
-    """Returns a dict, keyed by provider type string code, of internal provider
-    type ID.
-    """
-    global _PROVIDER_TYPE_MAP
-    if _PROVIDER_TYPE_MAP is not None:
-        return _PROVIDER_TYPE_MAP
-    tbl = resource_models.get_table('provider_types')
-    sel = sa.select([tbl.c.id, tbl.c.code])
-    sess = resource_models.get_session()
-    _PROVIDER_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
-    return _PROVIDER_TYPE_MAP
 
 
 def create_consumer_types(ctx):
@@ -410,7 +396,7 @@ def create_providers(ctx):
                 distance_ids[d_key] = res[0]
     ctx.status_ok()
 
-    compute_prov_type_id = get_provider_type_map()['runm.compute']
+    compute_prov_type_id = lookup.provider_type_id_from_code('runm.compute')
     ctx.status("creating providers")
     try:
         for p in ctx.deployment_config.providers.values():

--- a/load.py
+++ b/load.py
@@ -34,9 +34,9 @@ def reset_db(ctx):
     ctx.status_ok()
 
 
-def create_resource_classes(ctx):
-    ctx.status("creating resource classes")
-    tbl = resource_models.get_table('resource_classes')
+def create_resource_types(ctx):
+    ctx.status("creating resource types")
+    tbl = resource_models.get_table('resource_types')
 
     recs = [
         dict(
@@ -325,7 +325,7 @@ def create_provider_groups(ctx):
 
 
 def create_providers(ctx):
-    rc_tbl = resource_models.get_table('resource_classes')
+    rc_tbl = resource_models.get_table('resource_types')
     cap_tbl = resource_models.get_table('capabilities')
     part_tbl = resource_models.get_table('partitions')
     pg_tbl = resource_models.get_table('provider_groups')
@@ -342,7 +342,7 @@ def create_providers(ctx):
     part_ids = {}
     # in-process cache of provider group name -> internal ID
     pg_ids = {}
-    # in-process cache of resource class code -> internal ID
+    # in-process cache of resource type code -> internal ID
     rc_ids = {}
     # in-process cache of capability code -> internal ID
     cap_ids = {}
@@ -363,7 +363,7 @@ def create_providers(ctx):
             pg_ids[pg.uuid] = res[0]
     ctx.status_ok()
 
-    ctx.status("caching resource class and capability internal IDs")
+    ctx.status("caching resource type and capability internal IDs")
     for prof in ctx.deployment_config.provider_profiles.values():
         for rc_code in prof.inventory.keys():
             if rc_code not in rc_ids:
@@ -457,7 +457,7 @@ def create_providers(ctx):
                 rc_id = rc_ids[rc_code]
                 inv_rec = dict(
                     provider_id=p_id,
-                    resource_class_id=rc_id,
+                    resource_type_id=rc_id,
                     total=inv['total'],
                     reserved=inv['reserved'],
                     min_unit=inv['min_unit'],
@@ -503,7 +503,7 @@ def load(ctx):
     reset_db(ctx)
     metadata.create_object_types(ctx)
     create_provider_types(ctx)
-    create_resource_classes(ctx)
+    create_resource_types(ctx)
     create_consumer_types(ctx)
     create_capabilities(ctx)
     create_distances(ctx)

--- a/load.py
+++ b/load.py
@@ -108,6 +108,20 @@ def create_consumer_types(ctx):
         ctx.status_fail(err)
 
 
+def get_consumer_type_map():
+    """Returns a dict, keyed by consumer type string code, of internal consumer
+    type ID.
+    """
+    global _CONSUMER_TYPE_MAP
+    if _CONSUMER_TYPE_MAP is not None:
+        return _CONSUMER_TYPE_MAP
+    tbl = resource_models.get_table('consumer_types')
+    sel = sa.select([tbl.c.id, tbl.c.code])
+    sess = resource_models.get_session()
+    _CONSUMER_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
+    return _CONSUMER_TYPE_MAP
+
+
 def create_capabilities(ctx):
     ctx.status("creating capabilities")
     tbl = resource_models.get_table('capabilities')
@@ -400,7 +414,6 @@ def create_providers(ctx):
     ctx.status("creating providers")
     try:
         for p in ctx.deployment_config.providers.values():
-
             metadata.create_object(sess, 'runm.provider', p.uuid, p.name)
 
             # Create the base provider record

--- a/load.py
+++ b/load.py
@@ -6,12 +6,12 @@ import subprocess
 
 import sqlalchemy as sa
 
+import metadata
 import resource_models
 
 _RESOURCE_SCHEMA_FILE = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'resource_schema.sql',
 )
-_OBJECT_TYPE_MAP = None
 _PROVIDER_TYPE_MAP = None
 
 
@@ -32,55 +32,6 @@ def reset_db(ctx):
     )
     subprocess.check_output(cmd, shell=True)
     ctx.status_ok()
-
-
-def create_object_types(ctx):
-    ctx.status("creating object types")
-    tbl = resource_models.get_table('object_types')
-
-    recs = [
-        dict(
-            code="runm.partition",
-            description="A division of resources. A deployment unit for runm",
-        ),
-        dict(
-            code="runm.provider",
-            description="A provider of some resources, e.g. a compute node or "
-                        "an SR-IOV NIC",
-        ),
-        dict(
-            code="runm.provider_group",
-            description="A group of providers",
-        ),
-        dict(
-            code="runm.image",
-            description="A bootable bunch of bits",
-        ),
-        dict(
-            code="runm.machine",
-            description="Created by a user, a machine consumes compute "
-                        "resources from one of more providers",
-        ),
-    ]
-    try:
-        _insert_records(tbl, recs)
-        ctx.status_ok()
-    except Exception as err:
-        ctx.status_fail(err)
-
-
-def get_object_type_map():
-    """Returns a dict, keyed by object type string code, of internal object
-    type ID.
-    """
-    global _OBJECT_TYPE_MAP
-    if _OBJECT_TYPE_MAP is not None:
-        return _OBJECT_TYPE_MAP
-    tbl = resource_models.get_table('object_types')
-    sel = sa.select([tbl.c.id, tbl.c.code])
-    sess = resource_models.get_session()
-    _OBJECT_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
-    return _OBJECT_TYPE_MAP
 
 
 def create_resource_classes(ctx):
@@ -318,9 +269,7 @@ def create_distances(ctx):
 
 def create_partitions(ctx):
     ctx.status("creating partitions")
-    obj_tbl = resource_models.get_table('object_names')
     part_tbl = resource_models.get_table('partitions')
-    object_type_id = get_object_type_map()['runm.partition']
 
     sess = resource_models.get_session()
 
@@ -331,14 +280,9 @@ def create_partitions(ctx):
             part_uuid = p.partition.uuid
             if part_uuid in created:
                 continue
-            # Create the object lookup record
-            obj_rec = dict(
-                object_type=object_type_id,
-                uuid=part_uuid,
-                name=p.partition.name,
-            )
-            ins = obj_tbl.insert().values(**obj_rec)
-            sess.execute(ins)
+
+            metadata.create_object(
+                sess, 'runm.partition', part_uuid, p.partition.name)
 
             # Create the base provider group record
             part_rec = dict(
@@ -357,22 +301,14 @@ def create_partitions(ctx):
 
 def create_provider_groups(ctx):
     ctx.status("creating provider groups")
-    obj_tbl = resource_models.get_table('object_names')
     pg_tbl = resource_models.get_table('provider_groups')
-    object_type_id = get_object_type_map()['runm.provider_group']
 
     sess = resource_models.get_session()
 
     try:
         for pg in ctx.deployment_config.provider_groups.values():
-            # Create the object lookup record
-            obj_rec = dict(
-                object_type=object_type_id,
-                uuid=pg.uuid,
-                name=pg.name,
-            )
-            ins = obj_tbl.insert().values(**obj_rec)
-            sess.execute(ins)
+            metadata.create_object(
+                sess, 'runm.provider_group', pg.uuid, pg.name)
 
             # Create the base provider group record
             pg_rec = dict(
@@ -389,7 +325,6 @@ def create_provider_groups(ctx):
 
 
 def create_providers(ctx):
-    obj_tbl = resource_models.get_table('object_names')
     rc_tbl = resource_models.get_table('resource_classes')
     cap_tbl = resource_models.get_table('capabilities')
     part_tbl = resource_models.get_table('partitions')
@@ -475,19 +410,12 @@ def create_providers(ctx):
                 distance_ids[d_key] = res[0]
     ctx.status_ok()
 
-    object_type_id = get_object_type_map()['runm.provider']
     compute_prov_type_id = get_provider_type_map()['runm.compute']
     ctx.status("creating providers")
     try:
         for p in ctx.deployment_config.providers.values():
-            # Create the object lookup record
-            obj_rec = dict(
-                object_type=object_type_id,
-                uuid=p.uuid,
-                name=p.name,
-            )
-            ins = obj_tbl.insert().values(**obj_rec)
-            sess.execute(ins)
+
+            metadata.create_object(sess, 'runm.provider', p.uuid, p.name)
 
             # Create the base provider record
             part_id = part_ids[p.partition.uuid]
@@ -573,7 +501,7 @@ def create_providers(ctx):
 
 def load(ctx):
     reset_db(ctx)
-    create_object_types(ctx)
+    metadata.create_object_types(ctx)
     create_provider_types(ctx)
     create_resource_classes(ctx)
     create_consumer_types(ctx)

--- a/lookup.py
+++ b/lookup.py
@@ -1,0 +1,67 @@
+# Simple functions for getting heavily-cached simple lookups for type/class
+# information
+
+import os
+import subprocess
+
+import sqlalchemy as sa
+
+import metadata
+import resource_models
+
+_PROVIDER_TYPE_MAP = None
+_CONSUMER_TYPE_MAP = None
+_RESOURCE_TYPE_MAP = None
+
+def _get_provider_type_map():
+    """Returns a dict, keyed by provider type string code, of internal provider
+    type ID.
+    """
+    global _PROVIDER_TYPE_MAP
+    if _PROVIDER_TYPE_MAP is not None:
+        return _PROVIDER_TYPE_MAP
+    tbl = resource_models.get_table('provider_types')
+    sel = sa.select([tbl.c.id, tbl.c.code])
+    sess = resource_models.get_session()
+    _PROVIDER_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
+    return _PROVIDER_TYPE_MAP
+
+
+def provider_type_id_from_code(code):
+    return _get_provider_type_map()[code]
+
+
+def _get_consumer_type_map():
+    """Returns a dict, keyed by consumer type string code, of internal consumer
+    type ID.
+    """
+    global _CONSUMER_TYPE_MAP
+    if _CONSUMER_TYPE_MAP is not None:
+        return _CONSUMER_TYPE_MAP
+    tbl = resource_models.get_table('consumer_types')
+    sel = sa.select([tbl.c.id, tbl.c.code])
+    sess = resource_models.get_session()
+    _CONSUMER_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
+    return _CONSUMER_TYPE_MAP
+
+
+def consumer_type_id_from_code(code):
+    return _get_consumer_type_map()[code]
+
+
+def _get_resource_type_map():
+    """Returns a dict, keyed by resource type string code, of internal resource
+    type ID.
+    """
+    global _RESOURCE_TYPE_MAP
+    if _RESOURCE_TYPE_MAP is not None:
+        return _RESOURCE_TYPE_MAP
+    tbl = resource_models.get_table('resource_types')
+    sel = sa.select([tbl.c.id, tbl.c.code])
+    sess = resource_models.get_session()
+    _RESOURCE_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
+    return _RESOURCE_TYPE_MAP
+
+
+def resource_type_id_from_code(code):
+    return _get_resource_type_map()[code]

--- a/metadata.py
+++ b/metadata.py
@@ -1,0 +1,80 @@
+# Utilities that mock the runm-metadata services functionality around object
+# name-uuid and lookup objects
+
+import sqlalchemy as sa
+
+import resource_models
+
+_OBJECT_TYPE_MAP = None
+_PROVIDER_TYPE_MAP = None
+
+
+def _insert_records(tbl, recs):
+    sess = resource_models.get_session()
+    for rec in recs:
+        ins = tbl.insert().values(**rec)
+        sess.execute(ins)
+    sess.commit()
+
+
+def create_object_types(ctx):
+    ctx.status("creating object types")
+    tbl = resource_models.get_table('object_types')
+
+    recs = [
+        dict(
+            code="runm.partition",
+            description="A division of resources. A deployment unit for runm",
+        ),
+        dict(
+            code="runm.provider",
+            description="A provider of some resources, e.g. a compute node or "
+                        "an SR-IOV NIC",
+        ),
+        dict(
+            code="runm.provider_group",
+            description="A group of providers",
+        ),
+        dict(
+            code="runm.image",
+            description="A bootable bunch of bits",
+        ),
+        dict(
+            code="runm.machine",
+            description="Created by a user, a machine consumes compute "
+                        "resources from one of more providers",
+        ),
+    ]
+    try:
+        _insert_records(tbl, recs)
+        ctx.status_ok()
+    except Exception as err:
+        ctx.status_fail(err)
+
+
+def _get_object_type_map():
+    """Returns a dict, keyed by object type string code, of internal object
+    type ID.
+    """
+    global _OBJECT_TYPE_MAP
+    if _OBJECT_TYPE_MAP is not None:
+        return _OBJECT_TYPE_MAP
+    tbl = resource_models.get_table('object_types')
+    sel = sa.select([tbl.c.id, tbl.c.code])
+    sess = resource_models.get_session()
+    _OBJECT_TYPE_MAP = {r[1]: r[0] for r in sess.execute(sel)}
+    return _OBJECT_TYPE_MAP
+
+
+def create_object(sess, obj_type, uuid, name):
+    """Adds a new name-uuid pair to the object_names table."""
+    obj_tbl = resource_models.get_table('object_names')
+    object_type_id = _get_object_type_map()[obj_type]
+
+    obj_rec = dict(
+        object_type=object_type_id,
+        uuid=uuid,
+        name=name,
+    )
+    ins = obj_tbl.insert().values(**obj_rec)
+    sess.execute(ins)

--- a/metadata.py
+++ b/metadata.py
@@ -6,7 +6,6 @@ import sqlalchemy as sa
 import resource_models
 
 _OBJECT_TYPE_MAP = None
-_PROVIDER_TYPE_MAP = None
 
 
 def _insert_records(tbl, recs):

--- a/provider.py
+++ b/provider.py
@@ -1,0 +1,26 @@
+# functions for getting and setting information about a provider of resources
+
+import sqlalchemy as sa
+
+import resource_models
+
+
+def providers_by_uuids(uuids):
+    """Returns a dict, keyed by provider UUID, of Provider objects having one
+    of the supplied UUIDs
+    """
+    p_tbl = resource_models.get_table('providers')
+    cols = [
+        p_tbl.c.id,
+        p_tbl.c.uuid,
+        p_tbl.c.generation,
+    ]
+    sel = sa.select(cols).where(p_tbl.c.uuid.in_(uuids))
+    sess = resource_models.get_session()
+    return {
+        r[0]: resource_models.Provider(
+            id=r[0],
+            uuid=r[1],
+            generation=r[2],
+        ) for r in sess.execute(sel)
+    }

--- a/provider_profile.py
+++ b/provider_profile.py
@@ -30,10 +30,10 @@ class ProviderProfile(object):
         self.name = name
         # Simple list of capability names that the provider has
         self.capabilities = config_dict.get('capabilities', [])
-        # dict, keyed by resource class name, of inventory information this
+        # dict, keyed by resource type name, of inventory information this
         # provider profile contains. The inventory information includes total,
         # reserved, min_unit, max_unit, step_size and allocation_ratio data
-        # points for that resource class.
+        # points for that resource type.
         self.inventory = self._load_inventory(config_dict['inventory'])
 
     def __repr__(self):

--- a/resource_models.py
+++ b/resource_models.py
@@ -114,11 +114,12 @@ class Partition(object):
 
 
 class Provider(object):
-    def __init__(self, name=None, partition=None, groups=None, profile=None, id=None, uuid=None):
+    def __init__(self, name=None, partition=None, groups=None, profile=None, id=None, uuid=None, generation=None):
         self.id = id
         self.name = name
         self.partition = partition
         self.uuid = uuid or str(uuidlib.uuid4()).replace('-', '')
+        self.generation = generation
         # Collection of provider group objects this provider is in
         self.groups = groups
         self.profile = profile
@@ -154,10 +155,11 @@ class Provider(object):
 
 class Consumer(object):
     def __init__(self, name, uuid=None, project=None, user=None):
+        self.id = None
         self.name = name
         self.uuid = uuid or str(uuidlib.uuid4()).replace('-', '')
-        self.project = project
-        self.user = user
+        self.project = project or str(uuidlib.uuid4()).replace('-', '')
+        self.user = user or str(uuidlib.uuid4()).replace('-', '')
 
     def __repr__(self):
         uuid_str = ""

--- a/resource_models.py
+++ b/resource_models.py
@@ -25,7 +25,7 @@ _TABLE_NAMES = (
     'provider_trees',
     'provider_types',
     'providers',
-    'resource_classes',
+    'resource_types',
 )
 _TABLES = {}
 
@@ -178,15 +178,15 @@ class Consumer(object):
 
 
 class AllocationItem(object):
-    def __init__(self, provider, resource_class, used):
+    def __init__(self, provider, resource_type, used):
         self.provider = provider
-        self.resource_class = resource_class
+        self.resource_type = resource_type
         self.used = used
 
     def __repr__(self):
-        return "\n\t\tAllocationItem(provider=%s,resource_class=%s,used=%d)" % (
+        return "\n\t\tAllocationItem(provider=%s,resource_type=%s,used=%d)" % (
             self.provider,
-            self.resource_class,
+            self.resource_type,
             self.used,
         )
 

--- a/resource_schema.sql
+++ b/resource_schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE partitions (
 , UNIQUE INDEX uix_uuid (uuid)
 ) CHARACTER SET latin1 COLLATE latin1_bin;
 
-CREATE TABLE resource_classes (
+CREATE TABLE resource_types (
   id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
 , code VARCHAR(200) NOT NULL
 , description TEXT CHARACTER SET utf8 COLLATE utf8_bin NULL
@@ -97,15 +97,15 @@ CREATE TABLE provider_capabilities (
 CREATE TABLE inventories (
   id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
 , provider_id BIGINT NOT NULL
-, resource_class_id INT NOT NULL
+, resource_type_id INT NOT NULL
 , total BIGINT UNSIGNED NOT NULL
 , reserved BIGINT UNSIGNED NOT NULL
 , min_unit BIGINT UNSIGNED NOT NULL
 , max_unit BIGINT UNSIGNED NOT NULL
 , step_size BIGINT UNSIGNED NOT NULL
 , allocation_ratio FLOAT NOT NULL
-, UNIQUE INDEX uix_provider_resource_class (provider_id, resource_class_id)
-, INDEX ix_resource_class_total (resource_class_id, total)
+, UNIQUE INDEX uix_provider_resource_type (provider_id, resource_type_id)
+, INDEX ix_resource_type_total (resource_type_id, total)
 ) CHARACTER SET latin1 COLLATE latin1_bin;
 
 CREATE TABLE provider_groups (
@@ -166,14 +166,14 @@ CREATE TABLE allocation_items (
   id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
 , allocation_id BIGINT NOT NULL
 , provider_id BIGINT NOT NULL
-, resource_class_id INT NOT NULL
+, resource_type_id INT NOT NULL
 , used BIGINT UNSIGNED NOT NULL
-, INDEX ix_allocation_provider_resource_class (
+, INDEX ix_allocation_provider_resource_type (
     allocation_id
   , provider_id
-  , resource_class_id)
-, INDEX ix_resource_class_provider_allocation (
-    resource_class_id
+  , resource_type_id)
+, INDEX ix_resource_type_provider_allocation (
+    resource_type_id
   , provider_id
   , allocation_id)
 ) CHARACTER SET latin1 COLLATE latin1_bin;

--- a/resource_schema.sql
+++ b/resource_schema.sql
@@ -144,22 +144,20 @@ CREATE TABLE consumers (
 , type_id SMALLINT NOT NULL
 , uuid CHAR(32) NOT NULL
 , generation INT UNSIGNED NOT NULL
-, owner_account_uuid CHAR(32) NOT NULL
 , owner_project_uuid CHAR(32) NOT NULL
 , owner_user_uuid CHAR(32) NOT NULL
 , UNIQUE INDEX uix_uuid (uuid)
 , INDEX ix_type_id (type_id)
 , INDEX ix_owner (owner_project_uuid, owner_user_uuid)
-, INDEX ix_account_uuid (owner_account_uuid)
 ) CHARACTER SET latin1 COLLATE latin1_bin;
 
 CREATE TABLE allocations (
   id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
 , consumer_id BIGINT NOT NULL
-, claim_time BIGINT NOT NULL
-, release_time BIGINT NOT NULL
-, INDEX ix_consumer_window (consumer_id, claim_time, release_time)
-, INDEX ix_window (claim_time, release_time)
+, start_time BIGINT NOT NULL
+, end_time BIGINT NOT NULL
+, INDEX ix_consumer_window (consumer_id, start_time, end_time)
+, INDEX ix_window (start_time, end_time)
 ) CHARACTER SET latin1 COLLATE latin1_bin;
 
 CREATE TABLE allocation_items (

--- a/run.py
+++ b/run.py
@@ -110,20 +110,28 @@ def setup_opts(parser):
                         help="Claim configuration to use.")
 
 
-def main(ctx):
+def get_provider_profiles():
     prov_profiles = {}
     for fn in os.listdir(_PROVIDER_PROFILES_DIR):
         fp = os.path.join(_PROVIDER_PROFILES_DIR, fn)
         if os.path.isfile(fp) and fn.endswith('.yaml'):
             prof_name = fn[0:len(fn) - 5]
             prov_profiles[prof_name] = provider_profile.ProviderProfile(fp)
+    return prov_profiles
+
+
+def reset(ctx):
+    ctx.status("loading deployment config")
+    fp = os.path.join(_DEPLOYMENT_CONFIGS_DIR, args.deployment_config)
+    ctx.deployment_config = deployment_config.DeploymentConfig(
+        fp, get_provider_profiles())
+    ctx.status_ok()
+    load.load(ctx)
+
+
+def main(ctx):
     if ctx.args.reset:
-        ctx.status("loading deployment config")
-        fp = os.path.join(_DEPLOYMENT_CONFIGS_DIR, args.deployment_config)
-        ctx.deployment_config = deployment_config.DeploymentConfig(
-            fp, prov_profiles)
-        ctx.status_ok()
-        load.load(ctx)
+        reset(ctx)
     find_claims(ctx)
 
 

--- a/run.py
+++ b/run.py
@@ -18,7 +18,7 @@ _LOG_FORMAT = "%(level)s %(message)s"
 _DEPLOYMENT_CONFIGS_DIR = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'deployment-configs',
 )
-_DEFAULT_DEPLOYMENT_CONFIG = '1k-shared-compute'
+_DEFAULT_DEPLOYMENT_CONFIG = '100-shared-compute'
 _CLAIM_CONFIGS_DIR = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'claim-configs',
 )


### PR DESCRIPTION
To "execute a claim" essentially means to create allocation and allocation_items records in a transactional manner, consuming resources from the providers referenced in a Claim's `allocation_items`.

This PR contains a series of patches that add a number of refactorings that were needed as I fleshed out the claim execution process, including separating metadata, lookup and provider functionality out into their own Python files to make it easier to manage the growing claim.py module.

Issue #4