### PR TITLE
provider generation increment to claim execution

### DIFF
--- a/exception.py
+++ b/exception.py
@@ -1,0 +1,5 @@
+class GenerationConflict(Exception):
+    def __init__(self, object_type, object_uuid):
+        msg = "Generation conflict occurred. object_type=%s, object_uuid=%s"
+        super(GenerationConflict, self).__init__(
+            msg % (object_type, object_uuid))


### PR DESCRIPTION
Adds the step of incrementing the generation of all providers involved
in any allocation item of the claim during execution. This allows us to
retry the claim (and check capacity is not exceeded) when another thread
consumes inventory on a provider involved in our claim in between the
initial read of provider state and the end commit of the transaction.

Issue #4