### PR TITLE
add capacity checking to claim execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ varying scales (of deployment size).
 We test the data model and schema in Python because it's quick and easy to
 prototype things and run tests. We're not interested in comparing the raw speed
 of Golang versus Python. Rather, we're simply interested in quickly loading up
-a DB with varying scale scenarios, running claim and placement tests aghainst
+a DB with varying scale scenarios, running claim and placement tests against
 that DB, and tearing it all down.
 
 We use MySQL for the tests, though there's nothing preventing the use of

--- a/claim.py
+++ b/claim.py
@@ -560,8 +560,8 @@ def _find_providers_with_resource(ctx, claim_time, release_time,
       JOIN (
         SELECT id AS allocation_id
         FROM allocations
-        WHERE start_time >= $CLAIM_START
-        AND end_time < $CLAIM_END
+        WHERE acquire_time >= $CLAIM_START
+        AND release_time < $CLAIM_END
         GROUP BY id
       ) AS allocs_in_window
         ON ai.allocation_id = allocs_in_window
@@ -592,8 +592,8 @@ def _find_providers_with_resource(ctx, claim_time, release_time,
     ]
     allocs_in_window_subq = sa.select(alloc_window_cols).where(
         sa.and_(
-            alloc_tbl.c.start_time >= claim_time,
-            alloc_tbl.c.end_time < release_time,
+            alloc_tbl.c.acquire_time >= claim_time,
+            alloc_tbl.c.release_time < release_time,
         )
     ).group_by(alloc_tbl.c.id)
     allocs_in_window_subq = sa.alias(allocs_in_window_subq, "allocs_in_window")
@@ -750,8 +750,8 @@ def _create_allocation(sess, consumer, claim):
 
     ins = alloc_tbl.insert().values(
         consumer_id=consumer.id,
-        start_time=claim.claim_time,
-        end_time=claim.release_time,
+        acquire_time=claim.claim_time,
+        release_time=claim.release_time,
     )
     res = sess.execute(ins)
     if res.rowcount != 1:

--- a/consumer.py
+++ b/consumer.py
@@ -1,0 +1,47 @@
+# functions for getting and setting information about a consumer of resources
+
+import sqlalchemy as sa
+
+import lookup
+import metadata
+import resource_models
+
+
+def create_if_not_exists(sess, consumer):
+    """Creates a record of the supplied consumer in the database and sets the
+    consumer's internal id attribute.
+    """
+    if consumer.id is not None:
+        return
+
+    c_tbl = resource_models.get_table('consumers')
+
+    cols = [
+        c_tbl.c.id,
+        c_tbl.c.uuid,
+        c_tbl.c.owner_project_uuid,
+        c_tbl.c.owner_user_uuid,
+    ]
+    sel = sa.select(cols).where(c_tbl.c.uuid == consumer.uuid)
+
+    res = sess.execute(sel).fetchone()
+    if not res:
+        metadata.create_object(
+            sess, 'runm.machine', consumer.uuid, consumer.name)
+
+        type_id = lookup.consumer_type_id_from_code('runm.machine')
+        ins = c_tbl.insert().values(
+            uuid=consumer.uuid,
+            type_id=type_id,
+            owner_project_uuid=consumer.project,
+            owner_user_uuid=consumer.user,
+            generation=1,
+        )
+        res = sess.execute(ins)
+        if res.rowcount == 1:
+            c_id = res.inserted_primary_key[0]
+            consumer.id = c_id
+        # NOTE(jaypipes): Deliberately not committing, as this is done as part
+        # of the overall claim execution transaction.
+    else:
+        consumer.id = res['id']

--- a/exception.py
+++ b/exception.py
@@ -3,3 +3,53 @@ class GenerationConflict(Exception):
         msg = "Generation conflict occurred. object_type=%s, object_uuid=%s"
         super(GenerationConflict, self).__init__(
             msg % (object_type, object_uuid))
+
+
+class MissingInventory(Exception):
+    def __init__(self, provider, resource_type):
+        msg = ("Expected provider %s to have inventory in %s, but found no "
+               "inventory record." % (provider, resource_type))
+        super(MissingInventory, self).__init__(msg)
+
+
+class CapacityExceeded(Exception):
+    def __init__(self, provider, resource_type, requested_amount, total,
+            total_used, reserved, allocation_ratio):
+        msg = (
+            "A resource constraint was violated for provider %s and "
+            "resource %s: requested amount of %d was greater than the "
+            "provider's capacity. Capacity is calculated as ((total - used - "
+            "reserved) * allocation_ratio) where total = %d, used = %d, "
+            "reserved = %d and allocation_ratio = %f" % (
+                provider, resource_type, requested_amount, total, total_used,
+                reserved, allocation_ratio,
+            )
+        )
+        super(CapacityExceeded, self).__init__(msg)
+
+
+class MinUnitViolation(Exception):
+    def __init__(self, provider, resource_type, min_unit, requested_amount):
+        msg = ("A resource constraint was violated for provider %s and "
+               "resource %s: min unit of %d was greater than requested "
+               "amount of %d." % (
+                   provider, resource_type, min_unit, requested_amount))
+        super(MinUnitViolation, self).__init__(msg)
+
+
+class MaxUnitViolation(Exception):
+    def __init__(self, provider, resource_type, max_unit, requested_amount):
+        msg = ("A resource constraint was violated for provider %s and "
+               "resource %s: max unit of %d was less than requested "
+               "amount of %d." % (
+                   provider, resource_type, max_unit, requested_amount))
+        super(MaxUnitViolation, self).__init__(msg)
+
+
+class StepSizeViolation(Exception):
+    def __init__(self, provider, resource_type, step_size, requested_amount):
+        msg = ("A resource constraint was violated for provider %s and "
+               "resource %s: requested amount of %d was not aligned with "
+               "stepping size of %d." % (
+                   provider, resource_type, requested_amount, step_size))
+        super(StepSizeViolation, self).__init__(msg)

--- a/provider-profiles/12cpu-64G-4T-ssd-dedicated.yaml
+++ b/provider-profiles/12cpu-64G-4T-ssd-dedicated.yaml
@@ -22,6 +22,6 @@ inventory:
     total: 4000000000000
     allocation_ratio: 1.0
     # 10GB
-    min_unit: 10000000000
+    min_unit: 1000000000
     # 50GB
-    step_size: 10000000000
+    step_size: 1000000000

--- a/provider-profiles/24cpu-128G-1T-intel-hdd-shared.yaml
+++ b/provider-profiles/24cpu-128G-1T-intel-hdd-shared.yaml
@@ -24,6 +24,6 @@ inventory:
     total: 1000000000000
     allocation_ratio: 1.0
     # 10GB
-    min_unit: 10000000000
+    min_unit: 1000000000
     # 10GB
-    step_size: 10000000000
+    step_size: 1000000000

--- a/resource_schema.sql
+++ b/resource_schema.sql
@@ -154,10 +154,10 @@ CREATE TABLE consumers (
 CREATE TABLE allocations (
   id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
 , consumer_id BIGINT NOT NULL
-, start_time BIGINT NOT NULL
-, end_time BIGINT NOT NULL
-, INDEX ix_consumer_window (consumer_id, start_time, end_time)
-, INDEX ix_window (start_time, end_time)
+, acquire_time BIGINT NOT NULL
+, release_time BIGINT NOT NULL
+, INDEX ix_consumer_window (consumer_id, acquire_time, release_time)
+, INDEX ix_window (acquire_time, release_time)
 ) CHARACTER SET latin1 COLLATE latin1_bin;
 
 CREATE TABLE allocation_items (


### PR DESCRIPTION
Grabs the provider generations for providers involved in the claim's
allocation items, verifies that the providers and resource types still
meet the resource constraints and raise any exceptions if those resource
constraints are violated. This now makes the claim execution process
fully safe in multi-threaded environments where consumers are
concurrently acquiring resources from the same set of providers.
    
Issue #4
